### PR TITLE
Fix crash on 1.14.4 due to incorrect signature

### DIFF
--- a/src/main/java/com/gitlab/indigoa/fabric/informedload/mixin/MixinModelLoader.java
+++ b/src/main/java/com/gitlab/indigoa/fabric/informedload/mixin/MixinModelLoader.java
@@ -2,6 +2,7 @@ package com.gitlab.indigoa.fabric.informedload.mixin;
 
 import com.gitlab.indigoa.fabric.informedload.TaskList;
 import net.minecraft.block.Block;
+import net.minecraft.client.color.block.BlockColors;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.render.model.ModelLoader;
@@ -86,7 +87,7 @@ public class MixinModelLoader {
         //}
     }
     @Inject(method = "<init>", at = @At("RETURN"))
-    private void initDone(ResourceManager resourceManager, SpriteAtlasTexture spriteAtlasTexture, Profiler profiler, CallbackInfo ci) {
+    private void initDone(ResourceManager resourceManager, SpriteAtlasTexture spriteAtlasTexture, BlockColors colors, Profiler profiler, CallbackInfo ci) {
         //TaskList.removeTask("addmodels");
     }
     @Inject(method = "upload(Lnet/minecraft/util/profiler/Profiler;)V", at = @At("HEAD"))


### PR DESCRIPTION
A crash was reported on the Fabric Discord server that I traced back to this method. The signature of the constructor has changed in 1.14.4 to include a BlockColors instance, so I've included that in the signature of the mixin method. It would probably be better to entirely remove the method since it's effectively empty, but I'll leave that to your disgression.

[Crash report](https://pastebin.com/vdai49vx)